### PR TITLE
add unit for Schema Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Available for:
 - Confluent Kafka
+- Confluent Schema Registry
 - Confluent Kafka Connect
 - Confluent ZooKeeper
 - Confluent Control Center
@@ -53,6 +54,10 @@ JMX is enabled by default. To disable JXM remove the "Environment=" line.
 Kafka properties: /etc/kafka/server.properties </br>
 Logs: /var/log/kafka </br>
 JMX Port: 10030
+
+## Confluent Schema Registry
+Schema Registry properties: /etc/schema-registry/schema-registry.properties </br>
+JMX Port: 10050
 
 ## Confluent Kafka Connect
 Kafka Connect properties: /etc/kafka/connect-distributed.properties </br>

--- a/src/kafka-connect.service
+++ b/src/kafka-connect.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Apache Kafka Connect
-After=network.target
+After=network.target kafka.service schema-registry.service
 
 [Service]
 Type=simple

--- a/src/schema-registry.service
+++ b/src/schema-registry.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Confluent Schema Registry
+After=network.target remote-fs.target kafka.service
+
+[Service]
+Type=forking
+User=kafka
+Group=kafka
+Environment="KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=10050 -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false"
+Environment="LOG_DIR=/var/log/kafka"
+ExecStart=/usr/bin/schema-registry-start -daemon /etc/schema-registry/schema-registry.properties
+ExecStop=/usr/bin/schema-registry-stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds a unit file for the Schema Registry service (required for
Kafka Connect), as well as updating unit dependencies and the README.