### PR TITLE
Kafka connect improvements

### DIFF
--- a/src/kafka-connect.service
+++ b/src/kafka-connect.service
@@ -7,7 +7,7 @@ Type=forking
 User=kafka
 Group=kafka
 Environment="KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=10040 -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false"
-Environment="KAFKA_OPTS=-Dkafka.logs.dir=/var/log/kafka"
+Environment="LOG_DIR=/var/log/kafka"
 ExecStart=/usr/bin/connect-distributed -daemon /etc/kafka/connect-distributed.properties
 
 [Install]

--- a/src/kafka-connect.service
+++ b/src/kafka-connect.service
@@ -8,6 +8,8 @@ User=kafka
 Group=kafka
 Environment="KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=10040 -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false"
 Environment="LOG_DIR=/var/log/kafka"
+# Uncomment the following line to enable authentication for the kafka connect
+# Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/kafka_connect_jaas.conf"
 ExecStart=/usr/bin/connect-distributed -daemon /etc/kafka/connect-distributed.properties
 
 [Install]

--- a/src/kafka-connect.service
+++ b/src/kafka-connect.service
@@ -3,13 +3,12 @@ Description=Apache Kafka Connect
 After=network.target kafka.service schema-registry.service
 
 [Service]
-Type=simple
+Type=forking
 User=kafka
 Group=kafka
 Environment="KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=10040 -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false"
 Environment="KAFKA_OPTS=-Dkafka.logs.dir=/var/log/kafka"
-ExecStart=/usr/bin/connect-distributed /etc/kafka/connect-distributed.properties
+ExecStart=/usr/bin/connect-distributed -daemon /etc/kafka/connect-distributed.properties
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
Kafka-connect log directory is specified by LOG_DIR environment variable, previous KAFKA_OPTS doesn't work with Confluent platform 3.3.1. Also I added security variables and changed kafka-connect execution, so now it runs as daemon process.