### PR TITLE
Add required property java.security.krb5.conf

### DIFF
--- a/src/kafka.service
+++ b/src/kafka.service
@@ -9,7 +9,7 @@ Group=kafka
 Environment="KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=10030 -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false"
 Environment="LOG_DIR=/var/log/kafka"
 # Uncomment the following line to enable authentication for the broker
-# Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/kafka-jaas.conf"
+# Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/kafka-jaas.conf -Djava.security.krb5.conf=/etc/krb5.conf"
 ExecStart=/usr/bin/kafka-server-start -daemon /etc/kafka/server.properties
 ExecStop=/usr/bin/kafka-server-stop
 


### PR DESCRIPTION
Kafka with enabled security need specified path tokrb5.conf. Here is documentation https://docs.confluent.io/3.3.1/kafka/sasl.html#sasl-configuration-for-kafka-brokers